### PR TITLE
Launch divshot script using Node

### DIFF
--- a/services/service-divshot.js
+++ b/services/service-divshot.js
@@ -28,7 +28,7 @@ module.exports = {
 				}
 			], function(answers) {
 				if (answers.login) {
-					spawn(DIVSHOT_EXE, ["login"]).on("close", function(code) {
+					spawn("node", [DIVSHOT_EXE, "login"]).on("close", function(code) {
 						if (code) {
 							return defer.reject();
 						}


### PR DESCRIPTION
Use "node" as the executable instead of the script itself. This will make it work on Windows.
